### PR TITLE
Use official memcache store adapter

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ RailsSandbox::Application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production
-  config.cache_store = :dalli_store
+  config.cache_store = :mem_cache_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server
   # config.action_controller.asset_host = "http://assets.example.com"


### PR DESCRIPTION
Rails ships with it's own cache adapter on top of dalli. This isn't a big deal in Rails 3.2 but in Rails 5.2 the `:dalli_store` is not compatible with all caching options and can fail to invalidate silently.